### PR TITLE
Add YAML representation

### DIFF
--- a/app/controllers/api/JacksonRepresentation.java
+++ b/app/controllers/api/JacksonRepresentation.java
@@ -1,0 +1,60 @@
+package controllers.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import play.mvc.Result;
+import play.mvc.Results;
+import uk.gov.openregister.domain.Record;
+import uk.gov.openregister.domain.RecordVersionInfo;
+import uk.gov.openregister.validation.ValidationError;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static play.mvc.Results.ok;
+import static play.mvc.Results.status;
+
+public class JacksonRepresentation implements Representation {
+    protected final ObjectMapper objectMapper;
+    private final String contentType;
+
+    public JacksonRepresentation(ObjectMapper objectMapper, String contentType) {
+        this.objectMapper = objectMapper;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public Result toResponse(int status, String message) {
+        return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
+    }
+
+    @Override
+    public Result toListOfRecords(List<Record> records) throws JsonProcessingException {
+        return ok(asString(records)).as(contentType);
+    }
+
+    @Override
+    public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
+        return recordO.map(record -> ok(asString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
+    }
+
+    private String asString(Object record) {
+        try {
+            return objectMapper.writeValueAsString(record);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("status", statusCode);
+        result.put("message", message);
+        result.put("errors", errors);
+
+        return status(statusCode, asString(result)).as(contentType);
+    }
+}

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -1,7 +1,6 @@
 package controllers.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import play.mvc.Result;
@@ -36,15 +35,15 @@ public class JsonRepresentation implements Representation {
 
     @Override
     public Result toListOfRecords(List<Record> records) throws JsonProcessingException {
-        return ok(objectMapper.writeValueAsString(records)).as(contentType);
+        return ok(asString(records)).as(contentType);
     }
 
     @Override
     public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> ok(recordAsString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
+        return recordO.map(record -> ok(asString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
     }
 
-    private String recordAsString(Record record) {
+    private String asString(Object record) {
         try {
             return objectMapper.writeValueAsString(record);
         } catch (JsonProcessingException e) {
@@ -58,7 +57,7 @@ public class JsonRepresentation implements Representation {
         result.put("message", message);
         result.put("errors", errors);
 
-        return status(statusCode, (JsonNode) objectMapper.valueToTree(result));
+        return status(statusCode, asString(result)).as(contentType);
     }
 
     public static JsonRepresentation instance = new JsonRepresentation();

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -22,6 +22,7 @@ import static play.mvc.Results.status;
 public class JsonRepresentation implements Representation {
 
     private final ObjectMapper objectMapper;
+    private final String contentType = "application/json; charset=utf-8";
 
     public JsonRepresentation() {
         objectMapper = new ObjectMapper();
@@ -35,12 +36,12 @@ public class JsonRepresentation implements Representation {
 
     @Override
     public Result toListOfRecords(List<Record> records) throws JsonProcessingException {
-        return ok(objectMapper.writeValueAsString(records));
+        return ok(objectMapper.writeValueAsString(records)).as(contentType);
     }
 
     @Override
     public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> ok(recordAsString(record))).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
+        return recordO.map(record -> ok(recordAsString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
     }
 
     private String recordAsString(Record record) {

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -1,64 +1,18 @@
 package controllers.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import play.mvc.Result;
-import play.mvc.Results;
-import uk.gov.openregister.domain.Record;
-import uk.gov.openregister.domain.RecordVersionInfo;
-import uk.gov.openregister.validation.ValidationError;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static play.mvc.Results.ok;
-import static play.mvc.Results.status;
-
-public class JsonRepresentation implements Representation {
-
-    private final ObjectMapper objectMapper;
-    private final String contentType = "application/json; charset=utf-8";
-
+public class JsonRepresentation extends JacksonRepresentation {
     public JsonRepresentation() {
-        objectMapper = new ObjectMapper();
+        super(makeObjectMapper(), "application/json; charset=utf-8");
+    }
+
+    private static ObjectMapper makeObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        return objectMapper;
     }
 
-    @Override
-    public Result toResponse(int status, String message) {
-        return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
-    }
-
-    @Override
-    public Result toListOfRecords(List<Record> records) throws JsonProcessingException {
-        return ok(asString(records)).as(contentType);
-    }
-
-    @Override
-    public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> ok(asString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
-    }
-
-    private String asString(Object record) {
-        try {
-            return objectMapper.writeValueAsString(record);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", statusCode);
-        result.put("message", message);
-        result.put("errors", errors);
-
-        return status(statusCode, asString(result)).as(contentType);
-    }
-
-    public static JsonRepresentation instance = new JsonRepresentation();
+    public static JacksonRepresentation instance = new JsonRepresentation();
 }

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -3,6 +3,7 @@ package controllers.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import play.mvc.Result;
 import play.mvc.Results;
 import uk.gov.openregister.domain.Record;
@@ -19,6 +20,14 @@ import static play.mvc.Results.ok;
 import static play.mvc.Results.status;
 
 public class JsonRepresentation implements Representation {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonRepresentation() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    }
+
     @Override
     public Result toResponse(int status, String message) {
         return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
@@ -26,22 +35,30 @@ public class JsonRepresentation implements Representation {
 
     @Override
     public Result toListOfRecords(List<Record> records) throws JsonProcessingException {
-        return ok(new ObjectMapper().writeValueAsString(records));
+        return ok(objectMapper.writeValueAsString(records));
     }
 
     @Override
     public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> ok(record.toString())).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
+        return recordO.map(record -> ok(recordAsString(record))).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
     }
 
-    public static Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
+    private String recordAsString(Record record) {
+        try {
+            return objectMapper.writeValueAsString(record);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
         Map<String, Object> result = new HashMap<>();
         result.put("status", statusCode);
         result.put("message", message);
         result.put("errors", errors);
 
-        return status(statusCode, (JsonNode) new ObjectMapper().valueToTree(result));
+        return status(statusCode, (JsonNode) objectMapper.valueToTree(result));
     }
 
-    public static Representation instance = new JsonRepresentation();
+    public static JsonRepresentation instance = new JsonRepresentation();
 }

--- a/app/controllers/api/Representations.java
+++ b/app/controllers/api/Representations.java
@@ -4,6 +4,8 @@ public class Representations {
     public static Representation representationFor(String representation) {
         if ("json".equalsIgnoreCase(representation)) {
             return JsonRepresentation.instance;
+        } else if ("yaml".equalsIgnoreCase(representation)) {
+            return YamlRepresentation.instance;
         } else {
             return HtmlRepresentation.instance;
         }

--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -40,7 +40,7 @@ public class Rest extends Controller {
             return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
         }
 
-        return JsonRepresentation.toResponseWithErrors(400, "", validationErrors);
+        return JsonRepresentation.instance.toResponseWithErrors(400, "", validationErrors);
 
     }
 
@@ -59,7 +59,7 @@ public class Rest extends Controller {
             return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
         }
 
-        return JsonRepresentation.toResponseWithErrors(400, "", validationErrors);
+        return JsonRepresentation.instance.toResponseWithErrors(400, "", validationErrors);
     }
 
     public static F.Promise<Result> findByKey(String key, String value) {

--- a/app/controllers/api/YamlRepresentation.java
+++ b/app/controllers/api/YamlRepresentation.java
@@ -1,0 +1,13 @@
+package controllers.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class YamlRepresentation extends JacksonRepresentation {
+    public YamlRepresentation() {
+        super(new ObjectMapper(new YAMLFactory()), "text/yaml; charset=utf-8");
+    }
+
+    public static Representation instance = new YamlRepresentation();
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
   "org.mongodb" % "mongo-java-driver" % "3.0.0",
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-csv" % "2.5.2",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.5.2",
   "org.apache.httpcomponents" % "httpclient" % "4.3.1",
   "org.apache.httpcomponents" % "httpcore" % "4.3.1",
 

--- a/test/functional/json/ApplicationGlobalTest.java
+++ b/test/functional/json/ApplicationGlobalTest.java
@@ -12,14 +12,14 @@ public class ApplicationGlobalTest extends ApplicationTests {
     public void test404ErrorResponse() throws Exception {
         WSResponse response = postJson("/idonotexist?_representation=json", "{}");
         assertThat(response.getStatus()).isEqualTo(404);
-        assertThat(response.getBody()).isEqualTo("{\"message\":\"Page not found\",\"errors\":[],\"status\":404}");
+        assertThat(response.getBody()).isEqualTo("{\"errors\":[],\"message\":\"Page not found\",\"status\":404}");
     }
 
     @Test
     public void test400ErrorResponse() throws Exception {
         WSResponse response = postJson("/create?_representation=json", "{");
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(response.getBody()).isEqualTo("{\"message\":\"Invalid Json\",\"errors\":[],\"status\":400}");
+        assertThat(response.getBody()).isEqualTo("{\"errors\":[],\"message\":\"Invalid Json\",\"status\":400}");
     }
 
 }

--- a/test/functional/json/CreateRecordTest.java
+++ b/test/functional/json/CreateRecordTest.java
@@ -116,7 +116,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"\",\"name\":\"entryName\"}";
         WSResponse response = postJson("/supersede/" + record.getHash(), updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"message\":\"\",\"errors\":[{\"key\":\"test-register\",\"message\":\"Missing required key\"}],\"status\":400}");
+                .isEqualTo("{\"errors\":[{\"key\":\"test-register\",\"message\":\"Missing required key\"}],\"message\":\"\",\"status\":400}");
 
     }
 
@@ -125,7 +125,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"testregisterkey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/nonExistingHash", updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"errors\":[],\"status\":400}");
+                .isEqualTo("{\"errors\":[],\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"status\":400}");
 
     }
 
@@ -138,7 +138,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"new'PrimaryKey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/" + record.getHash(), updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"errors\":[],\"status\":400}");
+                .isEqualTo("{\"errors\":[],\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"status\":400}");
 
     }
 }

--- a/test/functional/yaml/YamlSanityTest.java
+++ b/test/functional/yaml/YamlSanityTest.java
@@ -1,0 +1,54 @@
+package functional.yaml;
+
+import functional.ApplicationTests;
+import org.junit.Test;
+import play.libs.ws.WSResponse;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.mvc.Http.Status.OK;
+
+public class YamlSanityTest extends ApplicationTests {
+
+    public static final String TEST_JSON = "{\"test-register\":\"testregisterkey\",\"name\":\"The Entry\",\"key1\": \"value1\",\"key2\": [\"A\",\"B\"]}";
+    public static final String EXPECTED_HASH = "4686f89b9c983f331c7deef476fda719148de4fb";
+    public static final String EXPECTED_YAML = "---\n" +
+            "hash: \"4686f89b9c983f331c7deef476fda719148de4fb\"\n" +
+            "entry:\n" +
+            "  key1: \"value1\"\n" +
+            "  key2:\n" +
+            "  - \"A\"\n" +
+            "  - \"B\"\n" +
+            "  name: \"The Entry\"\n" +
+            "  test-register: \"testregisterkey\"\n";
+
+    @Test
+    public void testFindOneByKey() throws Exception {
+        postJson("/create", TEST_JSON);
+
+        WSResponse response = getByKV("key1", "value1", "yaml");
+        assertThat(response.getStatus()).isEqualTo(OK);
+        assertThat(response.getBody()).isEqualTo(EXPECTED_YAML);
+    }
+
+    @Test
+    public void testFindOneByHash() throws Exception {
+        postJson("/create", TEST_JSON);
+
+        WSResponse response = getByHash(EXPECTED_HASH, "yaml");
+
+        assertThat(response.getStatus()).isEqualTo(OK);
+        assertThat(response.getBody()).isEqualTo(EXPECTED_YAML);
+    }
+
+
+    @Test
+    public void test404ErrorResponse() throws Exception {
+        WSResponse response = get("/idonotexist?_representation=yaml");
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getBody()).isEqualTo(
+                "---\n" +
+                        "message: \"Page not found\"\n" +
+                        "errors: []\n" +
+                        "status: 404\n");
+    }
+}


### PR DESCRIPTION
Also tidies up other code around representations

The YamlRepresentation shares a lot of code with JsonRepresentation,
because they both use Jackson's ObjectMapper under the covers.  As a
result, I've extracted a JacksonRepresentation class with the common
functionality of both.
