### PR TITLE
Deal with errors in turtle representation

### DIFF
--- a/app/controllers/api/HtmlRepresentation.java
+++ b/app/controllers/api/HtmlRepresentation.java
@@ -6,13 +6,11 @@ import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 
 import java.util.List;
-import java.util.Optional;
 
 import static play.mvc.Results.ok;
 import static play.mvc.Results.status;
 
 public class HtmlRepresentation implements Representation {
-    @Override
     public Result toResponse(int status, String message) {
         return status(status, views.html.error.render(message));
     }
@@ -23,11 +21,9 @@ public class HtmlRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record ->
-                (Result) ok(views.html.entry.render(App.instance.register.fields(), record, history)))
-                .orElse(toResponse(404, "Entry not found"));
+    public Result toRecord(Record record, List<RecordVersionInfo> history) {
+        return ok(views.html.entry.render(App.instance.register.fields(), record, history));
     }
 
-    public static Representation instance = new HtmlRepresentation();
+    public static HtmlRepresentation instance = new HtmlRepresentation();
 }

--- a/app/controllers/api/JacksonRepresentation.java
+++ b/app/controllers/api/JacksonRepresentation.java
@@ -3,30 +3,20 @@ package controllers.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import play.mvc.Result;
-import play.mvc.Results;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
-import uk.gov.openregister.validation.ValidationError;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static play.mvc.Results.ok;
-import static play.mvc.Results.status;
 
 public class JacksonRepresentation implements Representation {
-    protected final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
     private final String contentType;
 
     public JacksonRepresentation(ObjectMapper objectMapper, String contentType) {
         this.objectMapper = objectMapper;
         this.contentType = contentType;
-    }
-
-    public Result toResponse(int status, String message) {
-        return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
     }
 
     @Override
@@ -39,20 +29,11 @@ public class JacksonRepresentation implements Representation {
         return ok(asString(record)).as(contentType);
     }
 
-    private String asString(Object record) {
+    protected String asString(Object record) {
         try {
             return objectMapper.writeValueAsString(record);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", statusCode);
-        result.put("message", message);
-        result.put("errors", errors);
-
-        return status(statusCode, asString(result)).as(contentType);
     }
 }

--- a/app/controllers/api/JacksonRepresentation.java
+++ b/app/controllers/api/JacksonRepresentation.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static play.mvc.Results.ok;
 import static play.mvc.Results.status;
@@ -26,7 +25,6 @@ public class JacksonRepresentation implements Representation {
         this.contentType = contentType;
     }
 
-    @Override
     public Result toResponse(int status, String message) {
         return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
     }
@@ -37,8 +35,8 @@ public class JacksonRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> ok(asString(record)).as(contentType)).orElse(toResponseWithErrors(404, "Entry not found", Collections.<ValidationError>emptyList()));
+    public Result toRecord(Record record, List<RecordVersionInfo> history) {
+        return ok(asString(record)).as(contentType);
     }
 
     private String asString(Object record) {

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -2,10 +2,23 @@ package controllers.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import play.mvc.Result;
+import play.mvc.Results;
+import uk.gov.openregister.validation.ValidationError;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static play.mvc.Results.status;
 
 public class JsonRepresentation extends JacksonRepresentation {
+
+    public static final String CONTENT_TYPE = "application/json; charset=utf-8";
+
     public JsonRepresentation() {
-        super(makeObjectMapper(), "application/json; charset=utf-8");
+        super(makeObjectMapper(), CONTENT_TYPE);
     }
 
     private static ObjectMapper makeObjectMapper() {
@@ -14,5 +27,18 @@ public class JsonRepresentation extends JacksonRepresentation {
         return objectMapper;
     }
 
-    public static JacksonRepresentation instance = new JsonRepresentation();
+    public Result toResponse(int status, String message) {
+        return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
+    }
+
+    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("status", statusCode);
+        result.put("message", message);
+        result.put("errors", errors);
+
+        return status(statusCode, asString(result)).as(CONTENT_TYPE);
+    }
+
+    public static JsonRepresentation instance = new JsonRepresentation();
 }

--- a/app/controllers/api/Representation.java
+++ b/app/controllers/api/Representation.java
@@ -5,12 +5,9 @@ import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface Representation {
-    Result toResponse(int status, String message);
-
     Result toListOfRecords(List<Record> records) throws Exception;
 
-    Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history);
+    Result toRecord(Record record, List<RecordVersionInfo> history);
 }

--- a/app/controllers/api/TurtleRepresentation.java
+++ b/app/controllers/api/TurtleRepresentation.java
@@ -9,7 +9,6 @@ import uk.gov.openregister.domain.RecordVersionInfo;
 import uk.gov.openregister.model.Field;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -24,12 +23,6 @@ public class TurtleRepresentation implements Representation {
     public static final String TEXT_TURTLE = "text/turtle; charset=utf-8";
 
     @Override
-    public Result toResponse(int status, String message) {
-        // don't care about this for the moment
-        return null;
-    }
-
-    @Override
     public Result toListOfRecords(List<Record> records) throws Exception {
         return ok(records.stream()
                         .map(this::renderRecord)
@@ -38,9 +31,8 @@ public class TurtleRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Optional<Record> recordO, List<RecordVersionInfo> history) {
-        return recordO.map(record -> (Result) ok(TURTLE_HEADER + renderRecord(record)).as(TEXT_TURTLE))
-                .orElse(toResponse(404, "Not found"));
+    public Result toRecord(Record record, List<RecordVersionInfo> history) {
+        return ok(TURTLE_HEADER + renderRecord(record)).as(TEXT_TURTLE);
     }
 
     private String renderRecord(Record record) {

--- a/app/controllers/global/ApplicationGlobal.java
+++ b/app/controllers/global/ApplicationGlobal.java
@@ -1,7 +1,8 @@
 package controllers.global;
 
 import controllers.App;
-import controllers.api.Representation;
+import controllers.api.HtmlRepresentation;
+import controllers.api.JsonRepresentation;
 import play.Application;
 import play.GlobalSettings;
 import play.libs.F;
@@ -11,32 +12,25 @@ import play.mvc.Result;
 
 import java.lang.reflect.Method;
 
-import static controllers.api.Representations.representationFor;
-
 public class ApplicationGlobal extends GlobalSettings {
-    public static final String REPRESENTATION_QUERY_PARAM = "_representation";
-
     @Override
     public F.Promise<Result> onError(Http.RequestHeader requestHeader, Throwable throwable) {
-        Representation representation = representationFor(requestHeader.getQueryString(REPRESENTATION_QUERY_PARAM));
         return F.Promise.pure(
-                representation.toResponse(500, throwable.getMessage())
+                HtmlRepresentation.instance.toResponse(500, throwable.getMessage())
         );
     }
 
     @Override
     public F.Promise<Result> onHandlerNotFound(Http.RequestHeader requestHeader) {
-        Representation representation = representationFor(requestHeader.getQueryString(REPRESENTATION_QUERY_PARAM));
         return F.Promise.pure(
-                representation.toResponse(404, "Page not found")
+                HtmlRepresentation.instance.toResponse(404, "Page not found")
         );
     }
 
     @Override
     public F.Promise<Result> onBadRequest(Http.RequestHeader requestHeader, String s) {
-        Representation representation = representationFor(requestHeader.getQueryString(REPRESENTATION_QUERY_PARAM));
         return F.Promise.pure(
-                representation.toResponse(400, s)
+                JsonRepresentation.instance.toResponse(400, s)
         );
     }
 

--- a/test/functional/json/ApplicationGlobalTest.java
+++ b/test/functional/json/ApplicationGlobalTest.java
@@ -10,9 +10,8 @@ public class ApplicationGlobalTest extends ApplicationTests {
 
     @Test
     public void test404ErrorResponse() throws Exception {
-        WSResponse response = postJson("/idonotexist?_representation=json", "{}");
+        WSResponse response = postJson("/idonotexist", "{}");
         assertThat(response.getStatus()).isEqualTo(404);
-        assertThat(response.getBody()).isEqualTo("{\"errors\":[],\"message\":\"Page not found\",\"status\":404}");
     }
 
     @Test

--- a/test/functional/yaml/YamlSanityTest.java
+++ b/test/functional/yaml/YamlSanityTest.java
@@ -41,16 +41,4 @@ public class YamlSanityTest extends ApplicationTests {
         assertThat(response.getHeader("Content-type")).isEqualTo("text/yaml; charset=utf-8");
         assertThat(response.getBody()).isEqualTo(EXPECTED_YAML);
     }
-
-
-    @Test
-    public void test404ErrorResponse() throws Exception {
-        WSResponse response = get("/idonotexist?_representation=yaml");
-        assertThat(response.getStatus()).isEqualTo(404);
-        assertThat(response.getBody()).isEqualTo(
-                "---\n" +
-                        "message: \"Page not found\"\n" +
-                        "errors: []\n" +
-                        "status: 404\n");
-    }
 }


### PR DESCRIPTION
Before this change, a request to a nonexistent turtle page (eg
/foobar?_representation=turtle) would never respond, because
TurtleRepresentation#toResponse() returned a null rather than a valid
promise of a response.

However it didn't feel right to serve error pages in turtle format.

I've therefore changed the Representation interface to remove the
toResponse() method, which in practice was only used for errors (and
also the 202 Accepted response), and never served an actual record or
list of records.

This hardcodes errors to always be HTML for 500s and 404s, and JSON for 400s and 202s.
