### PR TITLE
Render spaces as %20 in URLs in turtle and HTML

### DIFF
--- a/app/controllers/api/TurtleRepresentation.java
+++ b/app/controllers/api/TurtleRepresentation.java
@@ -8,6 +8,8 @@ import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 import uk.gov.openregister.model.Field;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +63,13 @@ public class TurtleRepresentation implements Representation {
     private String renderScalar(Field field, JsonNode jsonNode) {
         if (field.getRegister().isPresent()) {
             String register = field.getRegister().get();
-            return String.format("<http://%s.openregister.org/%s/%s>", register, register, jsonNode.asText());
+            URI uri;
+            try {
+                uri = new URI("https", register + ".openregister.org", String.format("/%s/%s", register, jsonNode.asText()), null);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            return String.format("<%s>", uri);
         }
         return jsonNode.toString();
     }

--- a/app/controllers/api/TurtleRepresentation.java
+++ b/app/controllers/api/TurtleRepresentation.java
@@ -11,6 +11,7 @@ import uk.gov.openregister.linking.Curie;
 import uk.gov.openregister.linking.CurieResolver;
 import uk.gov.openregister.model.Field;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -45,7 +46,8 @@ public class TurtleRepresentation implements Representation {
     }
 
     private String renderRecord(Record record) {
-        String entity = String.format("<http://%s.openregister.org/hash/%s>\n", App.instance.register.name(), record.getHash());
+        URI hashUri = curieResolver.resolve(new Curie(App.instance.register.name() + "_hash", record.getHash()));
+        String entity = String.format("<%s>\n", hashUri);
         return App.instance.register.fields().stream()
                 .map(field -> String.format("  field:%s %s", field.getName(), renderValue(record, field)))
                 .collect(Collectors.joining(" ;\n", entity, " .\n"));

--- a/app/controllers/html/Utils.java
+++ b/app/controllers/html/Utils.java
@@ -5,9 +5,12 @@ import org.apache.commons.lang3.StringUtils;
 import play.twirl.api.Html;
 import uk.gov.openregister.StreamUtils;
 import uk.gov.openregister.config.ApplicationConf;
+import uk.gov.openregister.linking.Curie;
+import uk.gov.openregister.linking.CurieResolver;
 import uk.gov.openregister.model.Datatype;
 import uk.gov.openregister.model.Field;
 
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,7 +26,9 @@ public class Utils {
     }
 
     public static Html toLink(String register, String name) {
-        return Html.apply("<a class=\"link_to_register\" href=\"" + ApplicationConf.registerUrl(register, "/" + register + "/" + name) + "\">" + name + "</a>");
+        CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
+        URI uri = curieResolver.resolve(new Curie(register, name));
+        return Html.apply("<a class=\"link_to_register\" href=\"" + uri + "\">" + name + "</a>");
     }
 
     public static Html checkbox(Field field, List<String> checkedElements, List<String> options) {

--- a/app/uk/gov/openregister/config/GenericRegister.java
+++ b/app/uk/gov/openregister/config/GenericRegister.java
@@ -5,6 +5,8 @@ import org.apache.commons.lang3.text.WordUtils;
 import play.libs.ws.WS;
 import play.libs.ws.WSResponse;
 import uk.gov.openregister.StreamUtils;
+import uk.gov.openregister.linking.Curie;
+import uk.gov.openregister.linking.CurieResolver;
 import uk.gov.openregister.model.Field;
 
 import java.util.Collections;
@@ -29,7 +31,8 @@ public class GenericRegister extends Register {
 
         InitResult result = new InitResult(false);
 
-        String rrUrl =  ApplicationConf.registerUrl("register", "/register/" + name + "?_representation=json");
+        CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
+        String rrUrl =  curieResolver.resolve(new Curie("register", name)) + "?_representation=json";
         WSResponse rr = WS.client().url(rrUrl).execute().get(TIMEOUT);
 
         if (rr.getStatus() == 200 ) {
@@ -39,7 +42,7 @@ public class GenericRegister extends Register {
 
             fields = fieldNames.stream().map(field -> {
 
-                String frUrl = ApplicationConf.registerUrl("field", "/field/" + field + "?_representation=json");
+                String frUrl = curieResolver.resolve(new Curie("field", field)) + "?_representation=json";
                 WSResponse fr = WS.client().url(frUrl).execute().get(TIMEOUT);
 
                 if (fr.getStatus() == 200) {

--- a/app/uk/gov/openregister/linking/Curie.java
+++ b/app/uk/gov/openregister/linking/Curie.java
@@ -1,11 +1,11 @@
 package uk.gov.openregister.linking;
 
 public class Curie {
-    public final String register;
+    public final String namespace;
     public final String identifier;
 
-    public Curie(String register, String identifier) {
-        this.register = register;
+    public Curie(String namespace, String identifier) {
+        this.namespace = namespace;
         this.identifier = identifier;
     }
 }

--- a/app/uk/gov/openregister/linking/Curie.java
+++ b/app/uk/gov/openregister/linking/Curie.java
@@ -1,0 +1,11 @@
+package uk.gov.openregister.linking;
+
+public class Curie {
+    public final String register;
+    public final String identifier;
+
+    public Curie(String register, String identifier) {
+        this.register = register;
+        this.identifier = identifier;
+    }
+}

--- a/app/uk/gov/openregister/linking/CurieResolver.java
+++ b/app/uk/gov/openregister/linking/CurieResolver.java
@@ -15,7 +15,7 @@ public class CurieResolver {
         URI baseUri = URI.create(urlTemplate.replace(REGISTER_TOKEN, curie.register));
         String path = String.format("/%s/%s", curie.register, curie.identifier);
         try {
-            return new URI(baseUri.getScheme(), baseUri.getHost(), path, null);
+            return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/app/uk/gov/openregister/linking/CurieResolver.java
+++ b/app/uk/gov/openregister/linking/CurieResolver.java
@@ -1,0 +1,23 @@
+package uk.gov.openregister.linking;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class CurieResolver {
+    private static final String REGISTER_TOKEN = "__REGISTER__";
+    private final String urlTemplate;
+
+    public CurieResolver(String urlTemplate) {
+        this.urlTemplate = urlTemplate;
+    }
+
+    public URI resolve(Curie curie) {
+        URI baseUri = URI.create(urlTemplate.replace(REGISTER_TOKEN, curie.register));
+        String path = String.format("/%s/%s", curie.register, curie.identifier);
+        try {
+            return new URI(baseUri.getScheme(), baseUri.getHost(), path, null);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/app/uk/gov/openregister/linking/CurieResolver.java
+++ b/app/uk/gov/openregister/linking/CurieResolver.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 
 public class CurieResolver {
     private static final String REGISTER_TOKEN = "__REGISTER__";
+    private static final String NAMESPACE_SEPARATOR = "_";
     private final String urlTemplate;
 
     public CurieResolver(String urlTemplate) {
@@ -12,12 +13,23 @@ public class CurieResolver {
     }
 
     public URI resolve(Curie curie) {
-        URI baseUri = URI.create(urlTemplate.replace(REGISTER_TOKEN, curie.register));
-        String path = String.format("/%s/%s", curie.register, curie.identifier);
+        String register = getRegister(curie.namespace);
+        String field = getField(curie.namespace);
+        URI baseUri = URI.create(urlTemplate.replace(REGISTER_TOKEN, register));
+        String path = String.format("/%s/%s", field, curie.identifier);
         try {
             return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String getRegister(String namespace) {
+        return namespace.split(NAMESPACE_SEPARATOR)[0];
+    }
+
+    private String getField(String namespace) {
+        String[] namespaceParts = namespace.split(NAMESPACE_SEPARATOR);
+        return namespaceParts[namespaceParts.length - 1];
     }
 }

--- a/test/functional/rdf/RdfSanityTest.java
+++ b/test/functional/rdf/RdfSanityTest.java
@@ -13,8 +13,8 @@ public class RdfSanityTest extends ApplicationTests {
 
     public static final String EXPECTED_TURTLE = "@prefix field: <http://fields.openregister.org/field/>.\n" +
             "\n" +
-            "<http://test-register.openregister.org/hash/4686f89b9c983f331c7deef476fda719148de4fb>\n" +
-            "  field:test-register <http://test-register.openregister.org/test-register/testregisterkey> ;\n" +
+            "<http://localhost:8888/hash/4686f89b9c983f331c7deef476fda719148de4fb>\n" +
+            "  field:test-register <http://localhost:8888/test-register/testregisterkey> ;\n" +
             "  field:name \"The Entry\" ;\n" +
             "  field:key1 \"value1\" ;\n" +
             "  field:key2 \"A\", \"B\" .\n";
@@ -43,14 +43,14 @@ public class RdfSanityTest extends ApplicationTests {
 
     public static final String EXPECTED_TURTLE_LIST = "@prefix field: <http://fields.openregister.org/field/>.\n" +
             "\n" +
-            "<http://test-register.openregister.org/hash/39837068f586ab19bcb2b5f2408b024438e75c43>\n" +
-            "  field:test-register <http://test-register.openregister.org/test-register/testregisterkey1> ;\n" +
+            "<http://localhost:8888/hash/39837068f586ab19bcb2b5f2408b024438e75c43>\n" +
+            "  field:test-register <http://localhost:8888/test-register/testregisterkey1> ;\n" +
             "  field:name \"The Entry1\" ;\n" +
             "  field:key1 \"value1\" ;\n" +
             "  field:key2 \"A\", \"B\" .\n" +
             "\n" +
-            "<http://test-register.openregister.org/hash/b0c762fd934019b14a3ec88d775c6a037a09a74e>\n" +
-            "  field:test-register <http://test-register.openregister.org/test-register/testregisterkey2> ;\n" +
+            "<http://localhost:8888/hash/b0c762fd934019b14a3ec88d775c6a037a09a74e>\n" +
+            "  field:test-register <http://localhost:8888/test-register/testregisterkey2> ;\n" +
             "  field:name \"The Entry2\" ;\n" +
             "  field:key1 \"value2\" ;\n" +
             "  field:key2 \"C\", \"D\" .\n";

--- a/test/uk/gov/openregister/linking/CurieResolverTest.java
+++ b/test/uk/gov/openregister/linking/CurieResolverTest.java
@@ -25,4 +25,13 @@ public class CurieResolverTest {
         assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia:5555/widget/1234"));
     }
 
+    @Test
+    public void shouldEscapeSpacesInCurieValue() throws Exception {
+        CurieResolver resolver = new CurieResolver("http://__REGISTER__.register.elbonia");
+
+        URI widgetUri = resolver.resolve(new Curie("widget", "ABC DEF"));
+
+        assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia/widget/ABC%20DEF"));
+    }
+
 }

--- a/test/uk/gov/openregister/linking/CurieResolverTest.java
+++ b/test/uk/gov/openregister/linking/CurieResolverTest.java
@@ -34,4 +34,12 @@ public class CurieResolverTest {
         assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia/widget/ABC%20DEF"));
     }
 
+    @Test
+    public void shouldResolveHashBasedCurie() throws Exception {
+        CurieResolver resolver = new CurieResolver("http://__REGISTER__.register.elbonia");
+
+        URI widgetHashUri = resolver.resolve(new Curie("widget_hash", "abcdef123456"));
+
+        assertThat(widgetHashUri).isEqualTo(URI.create("http://widget.register.elbonia/hash/abcdef123456"));
+    }
 }

--- a/test/uk/gov/openregister/linking/CurieResolverTest.java
+++ b/test/uk/gov/openregister/linking/CurieResolverTest.java
@@ -1,0 +1,19 @@
+package uk.gov.openregister.linking;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class CurieResolverTest {
+    @Test
+    public void shouldResolveCurieBasedOnTemplate() throws Exception {
+        CurieResolver resolver = new CurieResolver("http://__REGISTER__.register.elbonia");
+
+        URI widgetUri = resolver.resolve(new Curie("widget", "1234"));
+
+        assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia/widget/1234"));
+    }
+
+}

--- a/test/uk/gov/openregister/linking/CurieResolverTest.java
+++ b/test/uk/gov/openregister/linking/CurieResolverTest.java
@@ -16,4 +16,13 @@ public class CurieResolverTest {
         assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia/widget/1234"));
     }
 
+    @Test
+    public void shouldResolveCurieBasedOnTemplateWithExplicitPort() throws Exception {
+        CurieResolver resolver = new CurieResolver("http://__REGISTER__.register.elbonia:5555");
+
+        URI widgetUri = resolver.resolve(new Curie("widget", "1234"));
+
+        assertThat(widgetUri).isEqualTo(URI.create("http://widget.register.elbonia:5555/widget/1234"));
+    }
+
 }


### PR DESCRIPTION
our turtle and html rendering could generate links with spaces, particularly when generating links to the postcode register.  This adds a class CurieResolver which owns the responsibility for generating links to records in registers, and makes TurtleRepresentation and HtmlRepresentation (via Utils) use it.
