### PR TITLE
About links

### DIFF
--- a/app/views/header.scala.html
+++ b/app/views/header.scala.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="header registry small-12 large-12 columns">
             <nav class="top-bar" data-topbar>
-                <h1><img id="header_crest" src="/assets/images/crest_white.png"/> <a href="/">@controllers.App.instance.register.friendlyName() Register</a></h1>
+                <h1><img id="header_crest" src="/assets/images/crest_white.png"/> <a href="/">@controllers.App.instance.register.friendlyName()</a> <a href="http://www.openregister.org">Register</a></h1>
             </nav>
         </div>
     </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -41,7 +41,8 @@
 
             <hr class="divider"/>
                 <ul class="side-nav">
-                    <li><a href="http://www.openregister.org/documentation">API Documentation</a></li>
+                    <li><a href="http://www.openregister.org/">About registers</a></li>
+                    <li><a href="http://www.openregister.org/developer">Developer documentation</a></li>
                 </ul>
         </div>
 </div>


### PR DESCRIPTION
Renamed "API Documentation" to "Developer documentation" and added links to http://www.openregister.org. 

I'm unhappy about hard-coding openregister.org, if someone wanted to parameterise that value, that would b grand!
