### PR TITLE
Add "latest version" and "this version" links to history section

### DIFF
--- a/app/controllers/api/HtmlRepresentation.java
+++ b/app/controllers/api/HtmlRepresentation.java
@@ -2,6 +2,7 @@ package controllers.api;
 
 import controllers.App;
 import play.mvc.Result;
+import uk.gov.openregister.domain.DbRecord;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 
@@ -22,8 +23,8 @@ public class HtmlRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Record record, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
-        return ok(views.html.entry.render(App.instance.register.fields(), record, history, representationsMap));
+    public Result toRecord(DbRecord dbRecord, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
+        return ok(views.html.entry.render(App.instance.register.fields(), dbRecord, history, representationsMap));
     }
 
     public static HtmlRepresentation instance = new HtmlRepresentation();

--- a/app/controllers/api/JacksonRepresentation.java
+++ b/app/controllers/api/JacksonRepresentation.java
@@ -3,6 +3,7 @@ package controllers.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import play.mvc.Result;
+import uk.gov.openregister.domain.DbRecord;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 
@@ -26,8 +27,8 @@ public class JacksonRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Record record, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
-        return ok(asString(record)).as(contentType);
+    public Result toRecord(DbRecord dbRecord, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
+        return ok(asString(dbRecord.getRecord())).as(contentType);
     }
 
     protected String asString(Object record) {

--- a/app/controllers/api/Representation.java
+++ b/app/controllers/api/Representation.java
@@ -1,6 +1,7 @@
 package controllers.api;
 
 import play.mvc.Result;
+import uk.gov.openregister.domain.DbRecord;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 
@@ -10,5 +11,5 @@ import java.util.Map;
 public interface Representation {
     Result toListOfRecords(List<Record> records, Map<String, String> representationsMap) throws Exception;
 
-    Result toRecord(Record record, List<RecordVersionInfo> history, Map<String, String> representationsMap);
+    Result toRecord(DbRecord record, List<RecordVersionInfo> history, Map<String, String> representationsMap);
 }

--- a/app/controllers/api/TurtleRepresentation.java
+++ b/app/controllers/api/TurtleRepresentation.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import controllers.App;
 import play.mvc.Result;
 import uk.gov.openregister.config.ApplicationConf;
+import uk.gov.openregister.domain.DbRecord;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
 import uk.gov.openregister.linking.Curie;
@@ -41,8 +42,8 @@ public class TurtleRepresentation implements Representation {
     }
 
     @Override
-    public Result toRecord(Record record, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
-        return ok(TURTLE_HEADER + renderRecord(record)).as(TEXT_TURTLE);
+    public Result toRecord(DbRecord dbRecord, List<RecordVersionInfo> history, Map<String, String> representationsMap) {
+        return ok(TURTLE_HEADER + renderRecord(dbRecord.getRecord())).as(TEXT_TURTLE);
     }
 
     private String renderRecord(Record record) {

--- a/app/controllers/html/Utils.java
+++ b/app/controllers/html/Utils.java
@@ -25,10 +25,14 @@ public class Utils {
         return toLink("datatype", datatype.getName());
     }
 
-    public static Html toLink(String register, String name) {
+    public static Html toLink(String register, String value) {
+        URI uri = toUri(register, value);
+        return Html.apply("<a class=\"link_to_register\" href=\"" + uri + "\">" + value + "</a>");
+    }
+
+    public static URI toUri(String register, String value) {
         CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
-        URI uri = curieResolver.resolve(new Curie(register, name));
-        return Html.apply("<a class=\"link_to_register\" href=\"" + uri + "\">" + name + "</a>");
+        return curieResolver.resolve(new Curie(register, value));
     }
 
     public static Html toRegisterLink(String registerName){

--- a/app/uk/gov/openregister/domain/DbRecord.java
+++ b/app/uk/gov/openregister/domain/DbRecord.java
@@ -2,18 +2,18 @@ package uk.gov.openregister.domain;
 
 public class DbRecord {
     private final Record record;
-    private final Metadata metaData;
+    private final Metadata metadata;
 
     public DbRecord(Record theRecord, Metadata theMetaData) {
         record = theRecord;
-        metaData = theMetaData;
+        metadata = theMetaData;
     }
 
     public Record getRecord() {
         return record;
     }
 
-    public Metadata getMetaData() {
-        return metaData;
+    public Metadata getMetadata() {
+        return metadata;
     }
 }

--- a/app/views/entry.scala.html
+++ b/app/views/entry.scala.html
@@ -1,4 +1,6 @@
-@(fields: List[uk.gov.openregister.model.Field], record: uk.gov.openregister.domain.Record, history: List[uk.gov.openregister.domain.RecordVersionInfo], representationsMap: Map[String, String])
+@(fields: List[uk.gov.openregister.model.Field], dbRecord: uk.gov.openregister.domain.DbRecord, history: List[uk.gov.openregister.domain.RecordVersionInfo], representationsMap: Map[String, String])
+
+@defining((dbRecord.getRecord, dbRecord.getMetadata)) {case (record,metadata) =>
 
 @main() {
 
@@ -38,6 +40,7 @@
             case _ => {}
         }}
 
+        @defining(org.joda.time.format.DateTimeFormat.forPattern("dd MMMM yyyy HH:mm:ss z")) { timeFormat =>
         <h2>History</h2>
         <h3>Latest version:</h3>
         @defining({
@@ -46,6 +49,8 @@
         }) { latestVersionUrl =>
         <p><a href="@latestVersionUrl">@latestVersionUrl</a></p>
         }
+        <h3>This version:</h3>
+        <p><a href="/hash/@{record.getHash}">@{record.getHash}</a> @{timeFormat.print(metadata.creationTime)}</p>
         <table>
             <thead>
                 <tr>
@@ -62,6 +67,7 @@
             }
             </tbody>
         </table>
+        }
     </div>
 </div>
 
@@ -72,4 +78,5 @@
 </div>
 @license()
 
+}
 }

--- a/app/views/entry.scala.html
+++ b/app/views/entry.scala.html
@@ -39,6 +39,13 @@
         }}
 
         <h2>History</h2>
+        <h3>Latest version:</h3>
+        @defining({
+            val registerName = controllers.App.instance.register.name;
+            controllers.html.Utils.toUri(registerName, record.getEntry.get(registerName).textValue)
+        }) { latestVersionUrl =>
+        <p><a href="@latestVersionUrl">@latestVersionUrl</a></p>
+        }
         <table>
             <thead>
                 <tr>

--- a/app/views/entry.scala.html
+++ b/app/views/entry.scala.html
@@ -39,24 +39,22 @@
         }}
 
         <h2>History</h2>
-        <div class="panel entry">
-            <table>
-                <thead>
-                    <tr>
-                        <td>hash</td>
-                        <td>timestamp</td>
-                    </tr>
-                </thead>
-                <tbody>
-                @history.map{ entry =>
+        <table>
+            <thead>
                 <tr>
-                    <td><span class="field-name">hash</span><span class="field-value"><a href="/hash/@entry.hash">@entry.hash</a></span></td>
-                    <td><span class="field-name">timestamp</span><span class="field-value">@entry.timestamp</span></td>
+                    <td>hash</td>
+                    <td>timestamp</td>
                 </tr>
-                }
-                </tbody>
-            </table>
-        </div>
+            </thead>
+            <tbody>
+            @history.map{ entry =>
+            <tr>
+                <td><span class="field-name">hash</span><span class="field-value"><a href="/hash/@entry.hash">@entry.hash</a></span></td>
+                <td><span class="field-name">timestamp</span><span class="field-value">@entry.timestamp</span></td>
+            </tr>
+            }
+            </tbody>
+        </table>
     </div>
 </div>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,7 +67,7 @@ logger.play=WARN
 logger.application=WARN
 
 # Name of this register
-register.name=register
+register.name=school
 register.name=${?REGISTER_NAME}
 
 # Register index page copy. Set these as enviroment variables to override


### PR DESCRIPTION
This adds "latest version" and "this version" links to the history section on the entry page.

See individual commit messages for more detail.

This PR makes no changes to the versions table - it still displays all versions.  A later PR will update that.

Screenshot: 
![screen shot 2015-05-19 at 18 31 14](https://cloud.githubusercontent.com/assets/581269/7709504/7129d154-fe55-11e4-84a4-13bc2754adb3.png)
