### PR TITLE
Improved copytext for Get the data section

### DIFF
--- a/app/views/data_formats.scala.html
+++ b/app/views/data_formats.scala.html
@@ -1,8 +1,8 @@
 @(representationsMap: Map[String, String])
-<h3>Get the data</h3>
-<span>
-    <h4>Download all entries:</h4>
+<h2>Data</h2>
+<p>This data is also available in the following representations:</p>
+<ul>
     @representationsMap.map { representation =>
-        <a href=@representation._2>@representation._1</a>
+        <li><a href=@representation._2>@representation._1</a></li>
     }
-</span>
+</ul>


### PR DESCRIPTION
Replaced the "Download all entries:" h4 heading which was the wrong size and misleading on a single entry with "This data is also available in the following representations:" and an unordered list of formats.
