### PR TITLE
409 response with better error when trying to supercede old version

### DIFF
--- a/app/uk/gov/openregister/store/DatabaseConflictException.java
+++ b/app/uk/gov/openregister/store/DatabaseConflictException.java
@@ -1,0 +1,7 @@
+package uk.gov.openregister.store;
+
+public class DatabaseConflictException extends DatabaseException {
+    public DatabaseConflictException(String msg) {
+        super(msg);
+    }
+}

--- a/app/uk/gov/openregister/store/postgresql/PostgresqlStore.java
+++ b/app/uk/gov/openregister/store/postgresql/PostgresqlStore.java
@@ -12,6 +12,7 @@ import uk.gov.openregister.domain.DbRecord;
 import uk.gov.openregister.domain.Metadata;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
+import uk.gov.openregister.store.DatabaseConflictException;
 import uk.gov.openregister.store.DatabaseException;
 import uk.gov.openregister.store.Store;
 
@@ -95,7 +96,7 @@ public class PostgresqlStore implements Store {
 
                 int result = st.executeUpdate();
                 if (result == 0) {
-                    throw new DatabaseException("Conflict-> Either this record is outdated or trying to update the primary key value.");
+                    throw new DatabaseConflictException("Either this record is outdated or attempted to update the primary key value.");
                 }
             }
 

--- a/test/functional/json/CreateRecordTest.java
+++ b/test/functional/json/CreateRecordTest.java
@@ -125,7 +125,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"testregisterkey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/nonExistingHash", updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"errors\":[],\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"status\":400}");
+                .isEqualTo("{\"errors\":[],\"message\":\"Either this record is outdated or attempted to update the primary key value.\",\"status\":400}");
 
     }
 
@@ -138,7 +138,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"new'PrimaryKey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/" + record.getHash(), updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"errors\":[],\"message\":\"Conflict-> Either this record is outdated or trying to update the primary key value.\",\"status\":400}");
+                .isEqualTo("{\"errors\":[],\"message\":\"Either this record is outdated or attempted to update the primary key value.\",\"status\":400}");
 
     }
 }


### PR DESCRIPTION
If you try to update an old record, you get an ugly page with a 500
error served by the ApplicationGlobal.onError() handler.  This
introduces a specific exception type for database conflicts, presents
a friendly page with the correct error code (409 Conflict), and improves
the error message.
