### PR TITLE
Serve errors as html

### DIFF
--- a/app/controllers/api/HtmlRepresentation.java
+++ b/app/controllers/api/HtmlRepresentation.java
@@ -4,9 +4,11 @@ import controllers.App;
 import play.mvc.Result;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.domain.RecordVersionInfo;
+import uk.gov.openregister.validation.ValidationError;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static play.mvc.Results.ok;
 import static play.mvc.Results.status;
@@ -14,6 +16,14 @@ import static play.mvc.Results.status;
 public class HtmlRepresentation implements Representation {
     public Result toResponse(int status, String message) {
         return status(status, views.html.error.render(message));
+    }
+
+    public Result toResponseWithErrors(int statusCode, List<ValidationError> errors) {
+        String validationErrorsString = errors.stream()
+                .map(error -> String.format("%s: %s", error.key, error.message))
+                .collect(Collectors.joining("; "));
+        String errorMessage = String.format("Some fields had validation errors: %s", validationErrorsString);
+        return toResponse(statusCode, errorMessage);
     }
 
     @Override

--- a/app/controllers/api/JsonRepresentation.java
+++ b/app/controllers/api/JsonRepresentation.java
@@ -3,14 +3,11 @@ package controllers.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import play.mvc.Result;
-import play.mvc.Results;
-import uk.gov.openregister.validation.ValidationError;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static play.mvc.Results.status;
 
 public class JsonRepresentation extends JacksonRepresentation {
@@ -27,17 +24,13 @@ public class JsonRepresentation extends JacksonRepresentation {
         return objectMapper;
     }
 
-    public Result toResponse(int status, String message) {
-        return toResponseWithErrors(status, message, Collections.<ValidationError>emptyList());
-    }
-
-    public Results.Status toResponseWithErrors(int statusCode, String message, List<ValidationError> errors) {
+    public Result createdResponse() {
         Map<String, Object> result = new HashMap<>();
-        result.put("status", statusCode);
-        result.put("message", message);
-        result.put("errors", errors);
+        result.put("status", 202);
+        result.put("message", "Record saved successfully");
+        result.put("errors", emptyList());
 
-        return status(statusCode, asString(result)).as(CONTENT_TYPE);
+        return status(202, asString(result)).as(CONTENT_TYPE);
     }
 
     public static JsonRepresentation instance = new JsonRepresentation();

--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static controllers.api.Representations.representationFor;
@@ -49,7 +48,7 @@ public class Rest extends Controller {
             try {
                 store.save(r);
             } catch (DatabaseException e) {
-                return JsonRepresentation.instance.toResponse(400, e.getMessage());
+                return HtmlRepresentation.instance.toResponse(400, e.getMessage());
             }
 
             return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
@@ -68,7 +67,7 @@ public class Rest extends Controller {
             try {
                 store.update(hash, r);
             } catch (DatabaseException e) {
-                return JsonRepresentation.instance.toResponse(400, e.getMessage());
+                return HtmlRepresentation.instance.toResponse(400, e.getMessage());
             }
             return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
         }

--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -51,10 +51,10 @@ public class Rest extends Controller {
                 return HtmlRepresentation.instance.toResponse(400, e.getMessage());
             }
 
-            return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
+            return JsonRepresentation.instance.createdResponse();
         }
 
-        return JsonRepresentation.instance.toResponseWithErrors(400, "", validationErrors);
+        return HtmlRepresentation.instance.toResponseWithErrors(400, validationErrors);
 
     }
 
@@ -69,10 +69,10 @@ public class Rest extends Controller {
             } catch (DatabaseException e) {
                 return HtmlRepresentation.instance.toResponse(400, e.getMessage());
             }
-            return JsonRepresentation.instance.toResponse(202, "Record saved successfully");
+            return JsonRepresentation.instance.createdResponse();
         }
 
-        return JsonRepresentation.instance.toResponseWithErrors(400, "", validationErrors);
+        return HtmlRepresentation.instance.toResponseWithErrors(400, validationErrors);
     }
 
     public F.Promise<Result> findByKey(String key, String value) {

--- a/app/controllers/global/ApplicationGlobal.java
+++ b/app/controllers/global/ApplicationGlobal.java
@@ -2,7 +2,6 @@ package controllers.global;
 
 import controllers.App;
 import controllers.api.HtmlRepresentation;
-import controllers.api.JsonRepresentation;
 import play.Application;
 import play.GlobalSettings;
 import play.Logger;
@@ -35,7 +34,7 @@ public class ApplicationGlobal extends GlobalSettings {
     @Override
     public F.Promise<Result> onBadRequest(Http.RequestHeader requestHeader, String s) {
         return F.Promise.pure(
-                JsonRepresentation.instance.toResponse(400, s)
+                HtmlRepresentation.instance.toResponse(400, s)
         );
     }
 

--- a/test/functional/json/ApplicationGlobalTest.java
+++ b/test/functional/json/ApplicationGlobalTest.java
@@ -18,7 +18,7 @@ public class ApplicationGlobalTest extends ApplicationTests {
     public void test400ErrorResponse() throws Exception {
         WSResponse response = postJson("/create?_representation=json", "{");
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(response.getBody()).isEqualTo("{\"errors\":[],\"message\":\"Invalid Json\",\"status\":400}");
+        assertThat(response.getHeader("Content-type")).contains("text/html");
     }
 
 }

--- a/test/functional/json/CreateRecordTest.java
+++ b/test/functional/json/CreateRecordTest.java
@@ -42,11 +42,8 @@ public class CreateRecordTest extends ApplicationTests {
         String json = "{\"test-register\":\"testregisterkey\",\"name\":\"entryName\",\"invalidKey\": \"value1\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/create", json);
 
-        JsonNode result = Json.parse(response.getBody());
-        assertEquals(400, result.get("status").asInt());
-        assertEquals("", result.get("message").textValue());
-        JSONAssert.assertEquals("[{\"key\":\"invalidKey\",\"message\":\"Key not required\"}]", result.get("errors").toString(), true);
-
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getBody()).contains("Key not required");
     }
 
     @Test
@@ -54,14 +51,7 @@ public class CreateRecordTest extends ApplicationTests {
         String json = "{\"name\":\"entryName\",\"invalidKey\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/create", json);
 
-        Map<String, Object> result = JsonObjectMapper.convert(response.getBody(), Map.class);
-
-        assertEquals(400, result.get("status"));
-        assertEquals("", result.get("message"));
-
-        List<Map> errors = (List) result.get("errors");
-        assertEquals(2, errors.size());
-        assertEquals(Arrays.asList("invalidKey", "test-register"), errors.stream().map(it -> it.get("key")).collect(Collectors.toList()));
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 
     @Test
@@ -116,7 +106,7 @@ public class CreateRecordTest extends ApplicationTests {
         String updatedJson = "{\"test-register\":\"\",\"name\":\"entryName\"}";
         WSResponse response = postJson("/supersede/" + record.getHash(), updatedJson);
         assertThat(response.getBody())
-                .isEqualTo("{\"errors\":[{\"key\":\"test-register\",\"message\":\"Missing required key\"}],\"message\":\"\",\"status\":400}");
+                .contains("Missing required key");
 
     }
 

--- a/test/functional/json/CreateRecordTest.java
+++ b/test/functional/json/CreateRecordTest.java
@@ -124,9 +124,7 @@ public class CreateRecordTest extends ApplicationTests {
     public void updateARecordReturns400Json_whenThereIsNoRecordWithTheGivenHash() {
         String updatedJson = "{\"test-register\":\"testregisterkey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/nonExistingHash", updatedJson);
-        assertThat(response.getBody())
-                .isEqualTo("{\"errors\":[],\"message\":\"Either this record is outdated or attempted to update the primary key value.\",\"status\":400}");
-
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 
     @Test
@@ -137,8 +135,6 @@ public class CreateRecordTest extends ApplicationTests {
 
         String updatedJson = "{\"test-register\":\"new'PrimaryKey\",\"name\":\"entryName\",\"key1\": \"value1\",\"key2\": \"value2\"}";
         WSResponse response = postJson("/supersede/" + record.getHash(), updatedJson);
-        assertThat(response.getBody())
-                .isEqualTo("{\"errors\":[],\"message\":\"Either this record is outdated or attempted to update the primary key value.\",\"status\":400}");
-
+        assertThat(response.getStatus()).isEqualTo(400);
     }
 }


### PR DESCRIPTION
This ensures that we always serve errors as html, even when receiving json from the user.
