### PR TITLE
Make fields of field register dynamic

### DIFF
--- a/app/uk/gov/openregister/FieldProvider.java
+++ b/app/uk/gov/openregister/FieldProvider.java
@@ -25,9 +25,9 @@ public class FieldProvider {
         if (rr.getStatus() == 200 ) {
             JsonNode rEntry = rr.asJson().get("entry");
 
-            List<String> fieldNames = StreamUtils.asStream(rEntry.get("fields").elements()).map(JsonNode::textValue).collect(Collectors.toList());
+            Stream<String> fieldNames = StreamUtils.asStream(rEntry.get("fields").elements()).map(JsonNode::textValue);
 
-            return fieldNames.stream().flatMap(field -> {
+            return fieldNames.flatMap(field -> {
                 String frUrl = curieResolver.resolve(new Curie("field", field)) + ".json";
                 WSResponse fr = WS.client().url(frUrl).get().get(GenericRegister.TIMEOUT);
 

--- a/app/uk/gov/openregister/FieldProvider.java
+++ b/app/uk/gov/openregister/FieldProvider.java
@@ -1,0 +1,49 @@
+package uk.gov.openregister;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import play.libs.ws.WS;
+import play.libs.ws.WSResponse;
+import uk.gov.openregister.config.ApplicationConf;
+import uk.gov.openregister.config.GenericRegister;
+import uk.gov.openregister.linking.Curie;
+import uk.gov.openregister.linking.CurieResolver;
+import uk.gov.openregister.model.Field;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+public class FieldProvider {
+    public static List<Field> getFields(String registerName, BiFunction<Integer, String, Object> errorHandler) {
+        // would be nice to cache some or all of these requests
+        CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
+        String rrUrl =  curieResolver.resolve(new Curie("register", registerName)) + ".json";
+        WSResponse rr = WS.client().url(rrUrl).get().get(GenericRegister.TIMEOUT);
+
+        if (rr.getStatus() == 200 ) {
+            JsonNode rEntry = rr.asJson().get("entry");
+
+            List<String> fieldNames = StreamUtils.asStream(rEntry.get("fields").elements()).map(JsonNode::textValue).collect(Collectors.toList());
+
+            return fieldNames.stream().map(field -> {
+
+                String frUrl = curieResolver.resolve(new Curie("field", field)) + ".json";
+                WSResponse fr = WS.client().url(frUrl).get().get(GenericRegister.TIMEOUT);
+
+                if (fr.getStatus() == 200) {
+                    JsonNode fEntry = fr.asJson().get("entry");
+                    return new Field(fEntry);
+                } else {
+                    errorHandler.apply(fr.getStatus(), frUrl);
+                    return new Field("unknown");
+                }
+
+            }).collect(Collectors.toList());
+        } else {
+            errorHandler.apply(rr.getStatus(), rrUrl);
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/app/uk/gov/openregister/config/FieldRegister.java
+++ b/app/uk/gov/openregister/config/FieldRegister.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 public class FieldRegister extends Register {
 
-    public static final List<Field> FIELDS = Arrays.asList(new Field("field"), new Field("datatype"), new Field("register", Optional.of("register")), new Field("cardinality"), new Field("text", Datatype.TEXT));
+    private List<Field> cachedFields = Arrays.asList(new Field("field"), new Field("datatype"), new Field("register", Optional.of("register")), new Field("cardinality"), new Field("text", Datatype.TEXT));
 
     private List<Record> registers = new ArrayList<>();
 
@@ -55,7 +55,12 @@ public class FieldRegister extends Register {
 
     @Override
     public List<Field> fields() {
-        return FIELDS;
+        List<Field> fetchedFields = GenericRegister.getFields(name(), (status, url) -> "ignored");
+        if (!fetchedFields.isEmpty()) {
+            cachedFields = fetchedFields;
+            return fetchedFields;
+        }
+        return cachedFields;
     }
 
     public List<Record> getRegisters() {

--- a/app/uk/gov/openregister/config/FieldRegister.java
+++ b/app/uk/gov/openregister/config/FieldRegister.java
@@ -2,6 +2,7 @@ package uk.gov.openregister.config;
 
 import play.libs.ws.WS;
 import play.libs.ws.WSResponse;
+import uk.gov.openregister.FieldProvider;
 import uk.gov.openregister.StreamUtils;
 import uk.gov.openregister.domain.Record;
 import uk.gov.openregister.model.Datatype;
@@ -55,7 +56,7 @@ public class FieldRegister extends Register {
 
     @Override
     public List<Field> fields() {
-        List<Field> fetchedFields = GenericRegister.getFields(name(), (status, url) -> "ignored");
+        List<Field> fetchedFields = FieldProvider.getFields(name(), (status, url) -> "ignored");
         if (!fetchedFields.isEmpty()) {
             cachedFields = fetchedFields;
             return fetchedFields;

--- a/app/uk/gov/openregister/config/GenericRegister.java
+++ b/app/uk/gov/openregister/config/GenericRegister.java
@@ -1,18 +1,11 @@
 package uk.gov.openregister.config;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.text.WordUtils;
-import play.libs.ws.WS;
-import play.libs.ws.WSResponse;
-import uk.gov.openregister.StreamUtils;
-import uk.gov.openregister.linking.Curie;
-import uk.gov.openregister.linking.CurieResolver;
+import uk.gov.openregister.FieldProvider;
 import uk.gov.openregister.model.Field;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 public class GenericRegister extends Register {
 
@@ -32,39 +25,9 @@ public class GenericRegister extends Register {
 
         InitResult result = new InitResult(false);
 
-        getFields(name, (status, url) -> result.errors().add("Error: got status " + status + " calling " + url));
+        FieldProvider.getFields(name, (status, url) -> result.errors().add("Error: got status " + status + " calling " + url));
         if(result.errors.isEmpty()) result.started = true;
         return result;
-    }
-
-    public static List<Field> getFields(String registerName, BiFunction<Integer, String, Object> errorHandler) {
-        CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
-        String rrUrl =  curieResolver.resolve(new Curie("register", registerName)) + ".json";
-        WSResponse rr = WS.client().url(rrUrl).execute().get(TIMEOUT);
-
-        if (rr.getStatus() == 200 ) {
-            JsonNode rEntry = rr.asJson().get("entry");
-
-            List<String> fieldNames = StreamUtils.asStream(rEntry.get("fields").elements()).map(JsonNode::textValue).collect(Collectors.toList());
-
-            return fieldNames.stream().map(field -> {
-
-                String frUrl = curieResolver.resolve(new Curie("field", field)) + ".json";
-                WSResponse fr = WS.client().url(frUrl).execute().get(TIMEOUT);
-
-                if (fr.getStatus() == 200) {
-                    JsonNode fEntry = fr.asJson().get("entry");
-                    return new Field(fEntry);
-                } else {
-                    errorHandler.apply(fr.getStatus(), frUrl);
-                    return new Field("unknown");
-                }
-
-            }).collect(Collectors.toList());
-        } else {
-            errorHandler.apply(rr.getStatus(), rrUrl);
-            return Collections.emptyList();
-        }
     }
 
     @Override

--- a/app/uk/gov/openregister/config/GenericRegister.java
+++ b/app/uk/gov/openregister/config/GenericRegister.java
@@ -11,6 +11,7 @@ import uk.gov.openregister.model.Field;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class GenericRegister extends Register {
@@ -31,8 +32,14 @@ public class GenericRegister extends Register {
 
         InitResult result = new InitResult(false);
 
+        getFields(name, (status, url) -> result.errors().add("Error: got status " + status + " calling " + url));
+        if(result.errors.isEmpty()) result.started = true;
+        return result;
+    }
+
+    public static List<Field> getFields(String registerName, BiFunction<Integer, String, Object> errorHandler) {
         CurieResolver curieResolver = new CurieResolver(ApplicationConf.getString("registers.service.template.url"));
-        String rrUrl =  curieResolver.resolve(new Curie("register", name)) + "?_representation=json";
+        String rrUrl =  curieResolver.resolve(new Curie("register", registerName)) + ".json";
         WSResponse rr = WS.client().url(rrUrl).execute().get(TIMEOUT);
 
         if (rr.getStatus() == 200 ) {
@@ -40,27 +47,24 @@ public class GenericRegister extends Register {
 
             List<String> fieldNames = StreamUtils.asStream(rEntry.get("fields").elements()).map(JsonNode::textValue).collect(Collectors.toList());
 
-            fields = fieldNames.stream().map(field -> {
+            return fieldNames.stream().map(field -> {
 
-                String frUrl = curieResolver.resolve(new Curie("field", field)) + "?_representation=json";
+                String frUrl = curieResolver.resolve(new Curie("field", field)) + ".json";
                 WSResponse fr = WS.client().url(frUrl).execute().get(TIMEOUT);
 
                 if (fr.getStatus() == 200) {
                     JsonNode fEntry = fr.asJson().get("entry");
                     return new Field(fEntry);
                 } else {
-                    result.errors().add("Field register returned " + fr.getStatus() + " calling " + frUrl);
+                    errorHandler.apply(fr.getStatus(), frUrl);
                     return new Field("unknown");
                 }
 
             }).collect(Collectors.toList());
-
-            if(result.errors.isEmpty()) result.started = true;
-
         } else {
-            result.errors().add("Register register returned " + rr.getStatus() + " calling " + rrUrl);
+            errorHandler.apply(rr.getStatus(), rrUrl);
+            return Collections.emptyList();
         }
-        return result;
     }
 
     @Override

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,7 +67,7 @@ logger.play=WARN
 logger.application=WARN
 
 # Name of this register
-register.name=datatype
+register.name=field
 register.name=${?REGISTER_NAME}
 
 # Register index page copy. Set these as enviroment variables to override


### PR DESCRIPTION
The fields in the field register are not dynamic. This caused a bug:
- the hardcoded value for the `datatype` field isn't configured to link to the datatype register
- the field register `datatype` record _is_ configured to link

so it looked like the datatype field _should_ be linking but it wasn't because the field register never read its own records to see how to render fields.

This makes the fields in the field register dynamic.  It's really rather chatty -- it'll make requests to the register register and field register for almost every page it renders -- but this could be resolved with client-side caching at some point.
