### PR TITLE
Tell google which URL for a resource is canonical

### DIFF
--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -69,6 +69,8 @@ public class Rest extends BaseController {
     }
 
     public F.Promise<Result> findByKey(String key, String value, String format) {
+        String canonicalUrl = routes.Rest.findByKey(key, value, "").url();
+        response().setHeader("Link", "<" + canonicalUrl + ">; rel=\"canonical\"");
         F.Promise<Optional<Record>> recordF = F.Promise.promise(() -> store.findByKV(key, URLDecoder.decode(value, "utf-8")));
         return recordF.map(optionalRecord ->
                         optionalRecord.map(record -> representationFrom(format).toRecord(
@@ -85,6 +87,8 @@ public class Rest extends BaseController {
     }
 
     public F.Promise<Result> findByHash(String hash, String format) {
+        String canonicalUrl = routes.Rest.findByHash(hash, "").url();
+        response().setHeader("Link", "<" + canonicalUrl + ">; rel=\"canonical\"");
         F.Promise<Optional<Record>> recordF = F.Promise.promise(() -> store.findByHash(hash));
         return recordF.map(optionalRecord ->
                         optionalRecord.map(record -> representationFrom(format).toRecord(

--- a/test/functional/json/FindEntriesTest.java
+++ b/test/functional/json/FindEntriesTest.java
@@ -22,6 +22,8 @@ public class FindEntriesTest extends ApplicationTests {
 
         WSResponse response = getByKV("key1", "value1", "json");
         assertThat(response.getStatus()).isEqualTo(OK);
+        String expectedLinkHeaderContents = "</key1/value1>; rel=\"canonical\"";
+        assertThat(response.getAllHeaders().get("Link")).contains(expectedLinkHeaderContents);
 
         final JsonNode responseJson = response.asJson();
 
@@ -37,6 +39,8 @@ public class FindEntriesTest extends ApplicationTests {
 
         WSResponse response = getByHash(record.getHash(), "json");
         assertThat(response.getStatus()).isEqualTo(OK);
+        String expectedLinkHeaderContents = "</hash/" + record.getHash() + ">; rel=\"canonical\"";
+        assertThat(response.getAllHeaders().get("Link")).contains(expectedLinkHeaderContents);
 
         final JsonNode responseJson = response.asJson();
 


### PR DESCRIPTION
This adds a Link: header to tell google and other crawlers which url is
the canonical URL for a resource.  RFC5988 defines the Link: header, and
https://support.google.com/webmasters/answer/139066?hl=en gives a good
summary of using it to define canonical URLs.

This makes it so that:

```
/hash/abcd.json
```

sets a header

```
Link: </hash/abcd> rel="canonical"
```

and

```
/key1/value1.json
```

sets a header

```
Link: </key1/value1> rel="canonical"
```

This works for all representations as it's done at the Rest level.
