### PR TITLE
page to explain different kinds of bulk download

### DIFF
--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -112,6 +112,16 @@ public class Rest extends BaseController {
                 Optional.of(store.getSearchSpec().getDefault()));
     }
 
+    public F.Promise<Result> bulkDownloadInfo() throws Exception {
+        return F.Promise.promise(() ->
+                ok(views.html.bulkDownloadInfo.render(register,"")));
+    }
+
+    public F.Promise<Result> bulkDownloadTorrent() throws Exception {
+        return F.Promise.promise(() ->
+                status(501, views.html.notImplemented.render(register)));
+    }
+
     public F.Promise<Result> latest(String format, Pager pager) throws Exception {
         return findByQuery(
                 format,

--- a/app/views/bulkDownloadInfo.scala.html
+++ b/app/views/bulkDownloadInfo.scala.html
@@ -1,0 +1,37 @@
+@(register: uk.gov.openregister.config.Register, lastUpdated: String)
+
+@main(register.friendlyName + " register") {
+
+    @header(register.friendlyName)
+
+
+    <div class="row">
+        <div class="small-12 large-8 columns">
+            <main>
+                <h1>Bulk download</h1>
+                <p>Download the current contents of this register as: <span style="display : inline-flex">
+                    @controllers.api.Representations.Format.values().filter(rep =>
+                        rep != controllers.api.Representations.Format.html).map(rep =>
+                        rep.name()).map { repname =>
+                            <a class="no-padding-left" download href=@controllers.api.routes.Rest.all(s".$repname", controllers.api.Pager.DEFAULT_PAGER)>@repname</a> &nbsp;
+                    }
+                    </span></p>
+                <p><a href="/download.torrent">Download the whole history of this register</a> as a CSV by bittorrent.</p>
+                <p>Once you have downloaded your copy of the register, you can keep your local copy up to date with the <a href="/latest">latest changes.</a></p>
+            </main>
+            @if(register.copyright()) {
+                <div class="copyright">
+                    <p class="label-text">Copyright:</p>
+                    <div class="copyright-details">@Html(register.copyright())</div>
+
+                </div>
+            }
+
+        </div>
+
+    </div>
+
+    @license()
+
+
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -55,20 +55,9 @@
             </form>
 
             <ul class="side-nav">
-                <li class="data-representations">Download all entries as:
-                    <span style="display : inline-flex">
-                    @controllers.api.Representations.Format.values().filter(rep =>
-                        rep != controllers.api.Representations.Format.html).map(rep =>
-                        rep.name()).map { repname =>
-                            <a class="no-padding-left" download href=@controllers.api.routes.Rest.all(s".$repname", controllers.api.Pager.DEFAULT_PAGER)>@repname</a> &nbsp;
-                    }
-                    </span>
-                </li>
-            </ul>
-
-            <ul class="side-nav">
                 <li><a href="http://www.openregister.org/">About registers</a></li>
                 <li><a href="http://www.openregister.org/developer">Developer documentation</a></li>
+                <li><a href="/download">Download all entries</a></li>
             </ul>
 
 

--- a/app/views/notImplemented.scala.html
+++ b/app/views/notImplemented.scala.html
@@ -1,0 +1,28 @@
+@(register: uk.gov.openregister.config.Register)
+
+@main(register.friendlyName + " register") {
+
+    @header(register.friendlyName)
+
+
+    <div class="row">
+        <div class="small-12 large-8 columns">
+            <main>
+                <h1>This page has not been implemented</h1>
+                <p>We haven't prioritised this work yet.  If you are interested in this feature, please let us know so we can adjust our priorities.</p>
+            </main>
+            @if(register.copyright()) {
+                <div class="copyright">
+                    <p class="label-text">Copyright:</p>
+                    <div class="copyright-details">@Html(register.copyright())</div>
+
+                </div>
+            }
+
+        </div>
+    </div>
+
+    @license()
+
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,8 @@ POST        /ui/supersede/:hash                                    @controllers.
 GET         /load                                                  @controllers.api.ImportData.loadWithProgress()
 GET         /load/progress                                         @controllers.api.ImportData.progress()
 
+GET         /download                                              @controllers.api.Rest.bulkDownloadInfo()
+GET         /download.torrent                                      @controllers.api.Rest.bulkDownloadTorrent()
 GET         /latest$format<(\.\p{Lower}+|)>                        @controllers.api.Rest.latest(format, pager: controllers.api.Pager ?= controllers.api.Pager.DEFAULT_PAGER)
 GET         /all$format<(\.\p{Lower}+|)>                           @controllers.api.Rest.all(format, pager: controllers.api.Pager ?= controllers.api.Pager.DEFAULT_PAGER)
 GET         /search                                                @controllers.api.Rest.search(pager: controllers.api.Pager ?= controllers.api.Pager.DEFAULT_PAGER)


### PR DESCRIPTION
Changed the sidebar download link:

![screen shot 2015-06-03 at 15 50 50](https://cloud.githubusercontent.com/assets/581269/7962965/5b8cff92-0a08-11e5-8585-2e4e95a0c233.png)

Which leads to a new page:
![screen shot 2015-06-03 at 15 51 24](https://cloud.githubusercontent.com/assets/581269/7962982/69171044-0a08-11e5-890e-b745aacd6a3c.png)

The "current contents" links are the old `all.<format>` URLs.  The "Download whole history" link shows a new page which is just a placeholder:

![screen shot 2015-06-03 at 15 52 31](https://cloud.githubusercontent.com/assets/581269/7963023/925d3eb0-0a08-11e5-9217-c9697b8e3763.png)
