### PR TITLE
support CORS headers

### DIFF
--- a/app/controllers/api/Rest.java
+++ b/app/controllers/api/Rest.java
@@ -138,6 +138,14 @@ public class Rest extends BaseController {
                 new URIBuilder(request.uri()).setParameter(REPRESENTATION_QUERY_PARAM, "__FORMAT__").build().toString());
     }
 
+    public F.Promise<Result> corsPreflight(String all) {
+        response().setHeader("Access-Control-Allow-Origin", "*");
+        response().setHeader("Allow", "*");
+        response().setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+        response().setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Referer, User-Agent");
+        return F.Promise.pure(ok());
+    }
+
     private F.Promise<Result> findByQuery(String format, Pager pager, Optional<SearchSpec.SearchHelper> sortBy, String representationUrlTemplate) throws Exception {
         Representation representation = representationFrom(format);
 

--- a/app/controllers/global/ApplicationGlobal.java
+++ b/app/controllers/global/ApplicationGlobal.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import play.GlobalSettings;
 import play.Logger;
 import play.libs.F;
+import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
 
@@ -31,6 +32,27 @@ public class ApplicationGlobal extends GlobalSettings {
         return F.Promise.pure(
                 HtmlRepresentation.instance.toResponse(400, s, registerName(requestHeader))
         );
+    }
+
+    // For CORS requests
+    @Override
+    public Action<?> onRequest(Http.Request request,
+                               java.lang.reflect.Method actionMethod) {
+        return new ActionWrapper(super.onRequest(request, actionMethod));
+    }
+
+    private class ActionWrapper extends Action.Simple {
+        public ActionWrapper(Action<?> action) {
+            this.delegate = action;
+        }
+
+        @Override
+        public F.Promise<Result> call(Http.Context ctx) throws java.lang.Throwable {
+            F.Promise<Result> result = this.delegate.call(ctx);
+            Http.Response response = ctx.response();
+            response.setHeader("Access-Control-Allow-Origin", "*");
+            return result;
+        }
     }
 
     private String registerName(Http.RequestHeader requestHeader) {

--- a/conf/routes
+++ b/conf/routes
@@ -33,3 +33,5 @@ GET         /assets/javascripts/routes                             @controllers.
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                                          controllers.Assets.at(path="/public", file)
 
+# CORS preflight checks
+OPTIONS /*all                                                      @controllers.api.Rest.corsPreflight(all)


### PR DESCRIPTION
There were a couple of requests at the hack day to support
[CORS headers](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).  We got by with JSONP instead, but CORS is a more
robust solution to the problem of cross-origin javascript requests.

This code is mostly copy-pasted from this stackoverflow answer:
http://stackoverflow.com/questions/25152277/play-framework-2-3-cors-headers

Basically we need to support two things:
1. an OPTIONS request needs to send an `Access-Control-Allow-Origin: *`
    header in the response.
2. a request to get data (especially JSON) should send an
    `Access-Control-Allow-Origin: *` header in the response.

This will will allow dynamic javascript requests to work.

I tested it with this javascript on a static page, and by viewing the
console output:

```
  <script>
    function successHandler(data) {
      console.log(data);
    }
    function errorHandler(status) {
      console.log("error");
      console.log(status);
    }
    var req = new XMLHttpRequest();
    req.open('get', 'http://register.openregister.dev:9000/register/school.json');
    req.onreadystatechange = function() {
      var status;
      var data;
      // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-readystate
      if (req.readyState == 4) { // `DONE`
        status = req.status;
        if (status == 200) {
          data = JSON.parse(req.responseText);
          successHandler && successHandler(data);
        } else {
          errorHandler && errorHandler(status);
        }
      }
    };
    req.send();
  </script>
```

without this commit, you get access denied errors because the
XMLHttpRequest violates the same-origin policy.  With this commit, you
get the requested data printed out in the console.
