### PR TITLE
Render full curie

### DIFF
--- a/app/controllers/html/Utils.java
+++ b/app/controllers/html/Utils.java
@@ -133,7 +133,7 @@ public class Utils {
             return toLink(Curie.of(field.getRegister().get(), value.textValue()), value.textValue()).text();
         } else if (field.getDatatype() == Datatype.CURIE) {
             Optional<Curie> curie = Curie.of(value.textValue());
-            return curie.map(c -> toLink(c, c.identifier).text()).orElse(value.textValue());
+            return curie.map(c -> toLink(c, value.textValue()).text()).orElse(value.textValue());
         } else {
             return value.textValue();
         }

--- a/app/controllers/html/Utils.java
+++ b/app/controllers/html/Utils.java
@@ -40,21 +40,24 @@ public class Utils {
     }
 
     public static Html toLink(Field field) {
-        return toLink("field", field.getName());
+        return toLink(Curie.of("field", field.getName()), field.getName());
     }
 
     public static Html toLink(Datatype datatype) {
-        return toLink("datatype", datatype.getName());
+        return toLink(Curie.of("datatype", datatype.getName()), datatype.getName());
     }
 
-    public static Html toLink(String register, String value) {
-        URI uri = toUri(register, value);
-        return Html.apply("<a class=\"link_to_register\" href=\"" + uri + "\">" + value + "</a>");
+    public static Html toLink(Curie curie, String linkText) {
+        URI uri = curieResolver().resolve(curie);
+        return toLink(uri, linkText);
     }
 
-    public static URI toUri(String register, String value) {
-        CurieResolver curieResolver = new CurieResolver(ApplicationConf.getRegisterServiceTemplateUrl());
-        return curieResolver.resolve(new Curie(register, value));
+    private static Html toLink(URI uri, String linkText) {
+        return Html.apply("<a class=\"link_to_register\" href=\"" + uri + "\">" + linkText + "</a>");
+    }
+
+    public static CurieResolver curieResolver() {
+        return new CurieResolver(ApplicationConf.getRegisterServiceTemplateUrl());
     }
 
     public static Html toRegisterLink(String registerName) {
@@ -127,10 +130,10 @@ public class Utils {
         } else if (value.isArray()) {
             return join(StreamUtils.asStream(value.elements()).map(e -> toRawValue(field, e)).collect(Collectors.toList()));
         } else if (field.getRegister().isPresent()) {
-            return toLink(field.getRegister().get(), value.textValue()).text();
+            return toLink(Curie.of(field.getRegister().get(), value.textValue()), value.textValue()).text();
         } else if (field.getDatatype() == Datatype.CURIE) {
             Optional<Curie> curie = Curie.of(value.textValue());
-            return curie.map(c -> toLink(c.namespace, c.identifier).text()).orElse(value.textValue());
+            return curie.map(c -> toLink(c, c.identifier).text()).orElse(value.textValue());
         } else {
             return value.textValue();
         }

--- a/app/uk/gov/openregister/linking/Curie.java
+++ b/app/uk/gov/openregister/linking/Curie.java
@@ -11,6 +11,10 @@ public class Curie {
         this.identifier = identifier;
     }
 
+    public static Curie of(String namespace, String identifier) {
+        return new Curie(namespace, identifier);
+    }
+
     public static Optional<Curie> of(String raw) {
         try {
             String[] split = raw.split(":", 2);

--- a/app/views/entry.scala.html
+++ b/app/views/entry.scala.html
@@ -57,8 +57,8 @@
 
             <h3>Latest version:</h3>
             @defining({
-            val registerName = register.name;
-            controllers.html.Utils.toUri(registerName, record.getEntry.get(registerName).textValue)
+            val recordCurie = uk.gov.openregister.linking.Curie.of(register.name, record.getEntry.get(register.name).textValue)
+            controllers.html.Utils.curieResolver.resolve(recordCurie)
             }) { latestVersionUrl =>
             <p><a href="@latestVersionUrl">@latestVersionUrl</a></p>
             }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -31,7 +31,7 @@
                 </p>
 
                 <p class="label-text">
-                    Fields in this register:</p><p class="homepage-field-labels">@Html(register.fieldNames.map(f => controllers.html.Utils.toLink("field", f).body).mkString(", "))</p>
+                    Fields in this register:</p><p class="homepage-field-labels">@Html(register.fields.map(f => controllers.html.Utils.toLink(f).body).mkString(", "))</p>
             </div>
 
             @if(register.copyright()) {

--- a/test/functional/UtilsTest.java
+++ b/test/functional/UtilsTest.java
@@ -32,7 +32,7 @@ public class UtilsTest extends ApplicationTests {
     @Test
     public void testRenderACurie() throws Exception {
 
-        assertThat(Utils.toValue(FIELD_WITH_CURIE, Json.parse("\"person-or-company:an-id\"")).text()).isEqualTo("<a class=\"link_to_register\" href=\"http://localhost:8888/person-or-company/an-id\">an-id</a>");
+        assertThat(Utils.toValue(FIELD_WITH_CURIE, Json.parse("\"person-or-company:an-id\"")).text()).isEqualTo("<a class=\"link_to_register\" href=\"http://localhost:8888/person-or-company/an-id\">person-or-company:an-id</a>");
     }
 
     @Test


### PR DESCRIPTION
When a field has a datatype of "curie", we should render the whole curie on the page, including the namespace.  Before this PR, we were only rendering the part to the right of the colon.
