### PR TITLE
Make alpha work with beta public-body register

### DIFF
--- a/app/uk/gov/openregister/config/Register.java
+++ b/app/uk/gov/openregister/config/Register.java
@@ -120,7 +120,7 @@ public abstract class Register {
 
     private void getRegistryDetails() {
         CurieResolver curieResolver = new CurieResolver(ApplicationConf.getRegisterServiceTemplateUrl());
-        String rrUrl = curieResolver.resolve(new Curie("public-body", registry())) + "?_representation=json";
+        String rrUrl = curieResolver.resolve(new Curie("public-body", registry())) + ".json";
         WSResponse rr = WS.client().url(rrUrl).execute().get(TIMEOUT);
 
         if (rr.getStatus() == 200) {


### PR DESCRIPTION
We've struggled to move the register, field and public-body registers to
the beta product, because is breaks all the other alpha registers such
as products-of-animal-origin-premises.

It turns out this was because when the alpha register tries to fetch the
public-body registry for the given register, it uses the
/public-body/foo?_representation=json URL which the beta no longer
supports.  The /public-body/foo.json URL is supported by both alpha and
beta, so this change is safe to merge in isolation.  Once this is
merged, we should be able to migrate the register, field and public-body
registers to the beta product.
